### PR TITLE
List axios as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
   "dependencies": {
     "i18next-xhr-backend": "^1.4.3"
   },
-  "devDependencies": {
+  "peerDependencies": {
     "axios": "^0.18.0",
+  },
+  "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "bower": "^1.8.2",


### PR DESCRIPTION
We abandoned use of i18next-fetch-backend in part because fetch was not listed as a peer dependency, and it called installation failure for our package. This change might resolve similar installation failures for other users.